### PR TITLE
CU-4v90dn - Fix number of online users not appearing

### DIFF
--- a/packages/sdk/src/services/graphql-api.ts
+++ b/packages/sdk/src/services/graphql-api.ts
@@ -758,6 +758,7 @@ export class GraphQLAPI {
           qnaId
           reactionsEnabled
           showEmojiButton
+          showOnlineUsersNumber
           unreadCount
         }
       }


### PR DESCRIPTION
Add "showOnlineUsersNumber" to graphql query